### PR TITLE
feat: media now saves to aws s3 bucket

### DIFF
--- a/de_duke/apis/drf/backend/main/settings/aws.py
+++ b/de_duke/apis/drf/backend/main/settings/aws.py
@@ -18,6 +18,16 @@ try:
 except Exception as e:
     print(f"Error retrieving SECRET_KEY: {e}")
 
+INSTALLED_APPS += [
+    "storages",
+]
+
+MEDIA_STORAGE_BUCKET_NAME = os.environ.get("MEDIA_STORAGE_BUCKET_NAME")
+STORAGE_REGION = os.environ.get("AWS_REGION")
+
+DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+MEDIA_URL = f"https://{MEDIA_STORAGE_BUCKET_NAME}.s3.{STORAGE_REGION}://"
+
 # Retrieve database credentials from AWS Secrets Manager
 try:
     DATABASE_CREDENTIALS_ARN = os.environ.get("DATABASE_CREDENTIALS_ARN")

--- a/de_duke/apis/drf/backend/requirements.txt
+++ b/de_duke/apis/drf/backend/requirements.txt
@@ -59,6 +59,7 @@ drf-spectacular
 uvicorn[standard]
 boto3
 botocore
+django-storages
 django-cognito-jwt
 numpy
 paystack-sdk

--- a/de_duke/apis/drf_api.py
+++ b/de_duke/apis/drf_api.py
@@ -8,6 +8,7 @@ from aws_cdk import (
     aws_elasticloadbalancingv2 as elbv2,
     aws_route53 as route53,
     aws_route53_targets as route53_targets,
+    aws_s3 as s3,
     Aws,
     Duration,
     CfnOutput,
@@ -48,6 +49,10 @@ class DrfApi(Construct):
                 exclude_characters="!@#$%^&*()_+",
             ),
         )
+        media_storage = s3.Bucket(
+            self,
+            "MediaStorage"
+        )
 
         user_data = ec2.UserData.for_linux()
         user_data.add_commands(
@@ -72,6 +77,7 @@ CPLUS_INCLUDE_PATH=/usr/include/gdal
 C_INCLUDE_PATH=/usr/include/gdal
 GDAL_LIBRARY_PATH=/usr/lib/libgdal.so
 DJANGO_SETTINGS_MODULE=main.settings.aws
+MEDIA_STORAGE_BUCKET_NAME={media_storage.bucket_name}
 {
                 "\n".join(
                     [


### PR DESCRIPTION
the progress is to make the media saves to aws s3 bucket instead of the host machine. This is to prevent inaccessible media as the host might change due to on asg configuration. 